### PR TITLE
Fix jobs query

### DIFF
--- a/services/api/store/postgres/data-agents/job.go
+++ b/services/api/store/postgres/data-agents/job.go
@@ -165,7 +165,9 @@ func (agent *PGJob) Search(ctx context.Context, filters *entities.JobFilters, te
 	}
 
 	query = pg.WhereAllowedTenants(query, "schedule.tenant_id", tenants).Order("id ASC")
-	query = pg.WhereAllowedOwner(query, "schedule.owner_id", ownerID)
+	if ownerID != "" {
+		query = pg.WhereAllowedOwner(query, "schedule.owner_id", ownerID)
+	}
 
 	err := pg.Select(ctx, query)
 	if err != nil {


### PR DESCRIPTION
When internal service `tx-sender` is called to `api` service it does not include jwt access_token or user info (ownerID) will be empty. The result of the query will not be correct (not found job).